### PR TITLE
/api/versions endpoint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,24 @@
 ## Backend Release Notes
 * ##### v3.0.0 - 2021-02-DD
 
+  * Fixed /api/versions endpoint [#45](https://github.com/YangCatalog/bottle-yang-extractor-validator/issues/45)
   * ConfD update [deployment #34](https://github.com/YangCatalog/deployment/issues/34)
   * Pyang validator update  [deployment #36]( https://github.com/YangCatalog/deployment/issues/36)
   * YumaPro validator update
-  * Fixed validation of a module/s in a .zip file
+  * Fixed validation of a module/s in a .zip file [#40](https://github.com/YangCatalog/bottle-yang-extractor-validator/issues/40)
   * Update of xym tool
   * Moved to Gunicorn from Uwsgi [deployment #39](https://github.com/YangCatalog/deployment/issues/39)
-  * Recursion problem fix
+  * Recursion problem fix [#32](https://github.com/YangCatalog/bottle-yang-extractor-validator/issues/32)
   * Update Dockerfile
   * Various major/minor bug fixes and improvements
-  
+
 * ##### v2.0.0 - 2020-08-14
 
   * Add health-check endpoint
   * Update of xym tool
   * Parameters loaded from config file
   * Various major/minor bug fixes and improvements
-  
+
 * ##### v1.1.0 - 2020-07-16
 
   * Fix yang failure [#30](https://github.com/YangCatalog/bottle-yang-extractor-validator/issues/30)
@@ -25,11 +26,11 @@
   * Update Dockerfile
   * Fix yang validator times out bug [#28](https://github.com/YangCatalog/bottle-yang-extractor-validator/issues/28)
   * Various major/minor bug fixes and improvements
-  
+
 * ##### v1.0.1 - 2020-07-03
 
   * Various major/minor bug fixes and improvements
-  
+
 * ##### v1.0.0 - 2020-06-23
 
   * Initial submitted version

--- a/yangvalidator/yangvalidator/views.py
+++ b/yangvalidator/yangvalidator/views.py
@@ -517,7 +517,8 @@ def datatracker_draft(request):
 
 
 def get_versions(request):
-    return versions
+    results = json.dumps(versions, cls=DjangoJSONEncoder)
+    return HttpResponse(results, content_type='application/json')
 
 
 def validate_rfc_param(request):


### PR DESCRIPTION
- /api/versions endpoint will now return json with versions information of validators
This fixes #45

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>